### PR TITLE
Replace old links of BetaWorld Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ The tool requires Windows 2000 or above.
 
 Support any PSF file with PSM/XML description file.
 
-A Chinese version of usage can be found on https://blog.betaworld.cn/32.
+A Chinese version of usage can be found on https://blog.betaworld.cn/archives/5/.


### PR DESCRIPTION
Due to the changes of BetaWorld website, the old link from BW Blogs are no longer available.
So I replaced the link.